### PR TITLE
docs: Add MCP integration walkthrough

### DIFF
--- a/libs/snowflake/docs/mcp_integration.ipynb
+++ b/libs/snowflake/docs/mcp_integration.ipynb
@@ -1,0 +1,263 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5a8fcdc7",
+   "metadata": {},
+   "source": [
+    "# Model Context Protocol (MCP) Integratiion\n",
+    "\n",
+    "This notebook demonstrates how to combine MCP Servers with the Langchain + Snowflake integration to leverage Snowflake Cortex models as the orchestrating model in MCP.\n",
+    "\n",
+    "## What You'll Learn\n",
+    "\n",
+    "1. **MCP Tools** - Unpacking MCP server tools as Langchain tools\n",
+    "2. **MCP Server Connection** - Connect Langchain chat with an MCP servers \n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "- Completed `getting_started.ipynb` and `snowflake_workflows.ipynb`\n",
+    "- Understanding of LangChain basics (chat models, tools, chains)\n",
+    "- Understanding of Model Context Protocol\n",
+    "\n",
+    "## Why These Patterns Matter\n",
+    "\n",
+    "The Langchain - Snowflake integration is the first open-source framework that combines Model Context Protocol with Snowflake Cortex LLMs as the orchestrating models. This combination allows an end-to-end MCP ecosystem to exist entirely within the Snowflake security perimeter.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48450d99",
+   "metadata": {},
+   "source": [
+    "## Installation\n",
+    "\n",
+    "Install additional package:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2cbfb3a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install --quiet -U langchain-mcp-adapters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be0ac810",
+   "metadata": {},
+   "source": [
+    "[langchain-mcp-adapters](https://github.com/langchain-ai/langchain-mcp-adapters) provides a lightweight wrapper that makes MCP Server tools compatible with LangChain binded tools. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2272c3a9",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "66ba194a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Session and LLM initialized successfully\n"
+     ]
+    }
+   ],
+   "source": [
+    "## Setup\n",
+    "from langchain_snowflake import ChatSnowflake, create_session_from_env\n",
+    "from langchain_mcp_adapters.tools import load_mcp_tools\n",
+    "from mcp import ClientSession\n",
+    "\n",
+    "\n",
+    "# Initialize session and LLM - consistent with other notebooks\n",
+    "session = create_session_from_env()\n",
+    "llm = ChatSnowflake(\n",
+    "    session=session, model=\"claude-4-sonnet\", temperature=0.1, max_tokens=2000\n",
+    ")\n",
+    "\n",
+    "print(\"Session and LLM initialized successfully\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8ba9f1d",
+   "metadata": {},
+   "source": [
+    "## MCP Server\n",
+    "We will use the [open-source MCP Server for Snowflake](https://github.com/Snowflake-Labs/mcp/tree/main) as an example. The MCP Server supports `stdio`, `streamable-http`, and `sse` transports. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2cada4b",
+   "metadata": {},
+   "source": [
+    "## 1. Synchronous Tool Calling with STDIO MCP Server"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e7c37aa2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initial response: content='I\\'ll create a transient database named \"my_langchain_db\" with replacement mode for you.' additional_kwargs={} response_metadata={'model': 'claude-4-sonnet', 'model_name': 'claude-4-sonnet', 'finish_reason': 'tool_calls'} id='run--1cb7b413-9bbb-44ef-8bb3-e1bafeb30b6f-0' tool_calls=[{'name': 'create_object', 'args': {'object_type': 'database', 'mode': 'replace', 'target_object': {'name': 'my_langchain_db', 'kind': 'TRANSIENT'}}, 'id': 'toolu_bdrk_017mBeWEVvyHFNC2UeUdZYhM', 'type': 'tool_call'}] usage_metadata={'input_tokens': 18462, 'output_tokens': 138, 'total_tokens': 18600}\n",
+      "Tools called: 1\n",
+      "Executing tool: create_object with args: {'object_type': 'database', 'mode': 'replace', 'target_object': {'name': 'my_langchain_db', 'kind': 'TRANSIENT'}}\n",
+      "Created Database my_langchain_db.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from mcp import StdioServerParameters\n",
+    "from mcp.client.stdio import stdio_client\n",
+    "\n",
+    "server_params = StdioServerParameters(\n",
+    "    command=\"uvx\",\n",
+    "    args=[\n",
+    "        \"snowflake-labs-mcp\", \n",
+    "        \"--service-config-file\", \n",
+    "        \"/Users/jsummer/.snowflake/mcp_config.yaml\", # Change to configuration file path\n",
+    "        \"--connection-name\", \n",
+    "        \"default\", \n",
+    "        \"--transport\",\n",
+    "        \"stdio\"\n",
+    "        ],\n",
+    ")\n",
+    "\n",
+    "prompt = \"create a transient database named my_langchain_db with replacement\"\n",
+    "\n",
+    "async with stdio_client(server_params) as (read, write):\n",
+    "    async with ClientSession(read, write) as client_session:\n",
+    "        \n",
+    "        # Initialize the connection\n",
+    "        await client_session.initialize()\n",
+    "\n",
+    "        # Get tools\n",
+    "        tools = await load_mcp_tools(client_session)\n",
+    "        agent = llm.bind_tools(tools, auto_execute=False)\n",
+    "\n",
+    "        # Use sync invoke for the LLM, but handle async tools manually\n",
+    "        response = agent.invoke(prompt)\n",
+    "        print(\"Initial response:\", response)\n",
+    "        \n",
+    "        # If tools were called, execute them manually\n",
+    "        if hasattr(response, 'tool_calls') and response.tool_calls:\n",
+    "            print(f\"Tools called: {len(response.tool_calls)}\")\n",
+    "            for tool_call in response.tool_calls:\n",
+    "                tool_name = tool_call['name']\n",
+    "                tool_args = tool_call['args']\n",
+    "                print(f\"Executing tool: {tool_name} with args: {tool_args}\")\n",
+    "\n",
+    "                result = await client_session.call_tool(tool_name, tool_args)\n",
+    "                for content in result.content:\n",
+    "                    if content.type == 'text':\n",
+    "                        print(content.text)\n",
+    "\n",
+    "        else:\n",
+    "            print(response.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db4a6567",
+   "metadata": {},
+   "source": [
+    "## 2. Synchronous Tool Calling with HTTP-streaming MCP Server\n",
+    "\n",
+    "Start the MCP Server with streamable-http transport. Endpoint `http://0.0.0.0:9000/mcp/` surfaced..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "390a24d6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initial response: content='I\\'ll create a transient database named \"my_langchain_db\" with replacement mode for you.' additional_kwargs={} response_metadata={'model': 'claude-4-sonnet', 'model_name': 'claude-4-sonnet', 'finish_reason': 'tool_calls'} id='run--cdc66d35-423e-44d7-84b8-1931ce2e42ab-0' tool_calls=[{'name': 'create_object', 'args': {'object_type': 'database', 'mode': 'replace', 'target_object': {'name': 'my_langchain_db', 'kind': 'TRANSIENT'}}, 'id': 'toolu_bdrk_019HeD351AgVFG9BnSpgXgwF', 'type': 'tool_call'}] usage_metadata={'input_tokens': 18462, 'output_tokens': 138, 'total_tokens': 18600}\n",
+      "Tools called: 1\n",
+      "Executing tool: create_object with args: {'object_type': 'database', 'mode': 'replace', 'target_object': {'name': 'my_langchain_db', 'kind': 'TRANSIENT'}}\n",
+      "Created Database my_langchain_db.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from mcp.client.streamable_http import streamablehttp_client\n",
+    "\n",
+    "\n",
+    "prompt = \"create a transient database named my_langchain_db with replacement\"\n",
+    "\n",
+    "async with streamablehttp_client(\"http://0.0.0.0:9000/mcp/\") as (read, write, _):\n",
+    "    async with ClientSession(read, write) as client_session:\n",
+    "        # Initialize the connection\n",
+    "        await client_session.initialize()\n",
+    "\n",
+    "        # Get tools\n",
+    "        tools = await load_mcp_tools(client_session)\n",
+    "        agent = llm.bind_tools(tools, auto_execute=False)\n",
+    "\n",
+    "        # Use sync invoke for the LLM, but handle async tools manually\n",
+    "        response = agent.invoke(prompt)\n",
+    "        print(\"Initial response:\", response)\n",
+    "        \n",
+    "        # If tools were called, execute them manually\n",
+    "        if hasattr(response, 'tool_calls') and response.tool_calls:\n",
+    "            print(f\"Tools called: {len(response.tool_calls)}\")\n",
+    "            for tool_call in response.tool_calls:\n",
+    "                tool_name = tool_call['name']\n",
+    "                tool_args = tool_call['args']\n",
+    "                print(f\"Executing tool: {tool_name} with args: {tool_args}\")\n",
+    "\n",
+    "                result = await client_session.call_tool(tool_name, tool_args)\n",
+    "                for content in result.content:\n",
+    "                    if content.type == 'text':\n",
+    "                        print(content.text)\n",
+    "                        \n",
+    "        else:\n",
+    "            print(response.content)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds example of using [snowflake-labs-mcp](https://github.com/Snowflake-Labs/mcp/tree/main) MCP Server with langchain-snowflake Chat model class. MCP Server tools are adapted to langchain tools and MCP Client is used to execute MCP Server tools.