### PR TITLE
fix: convert underscores to dashes in account name for SSL verification

### DIFF
--- a/libs/snowflake/langchain_snowflake/_connection/rest_client.py
+++ b/libs/snowflake/langchain_snowflake/_connection/rest_client.py
@@ -321,6 +321,9 @@ class RestApiClient:
             # Extract account name (remove region/cloud info if present)
             account_name = account_info.split(".")[0] if "." in account_info else account_info
 
+            # Snowflake TLS certificates use hyphens, not underscores, in hostnames.
+            account_name = account_name.replace("_", "-")
+
             # Build base URL following Snowflake REST API patterns
             return f"https://{account_name}.snowflakecomputing.com"
 


### PR DESCRIPTION
Snowflake account names containing underscores cause SSL certificate
verification failures because the generated hostname does not match the
certificate's CN/SAN. Convert underscores to dashes when building the
account hostname so the TLS handshake succeeds.