### PR TITLE
fix(rest-client): include empty JSON body in POST requests

### DIFF
--- a/libs/snowflake/langchain_snowflake/_connection/rest_client.py
+++ b/libs/snowflake/langchain_snowflake/_connection/rest_client.py
@@ -76,7 +76,7 @@ class RestApiClient:
         }
 
         # Add payload if provided
-        if payload:
+        if payload is not None:
             request_config["json"] = payload
 
         # Add query parameters if provided

--- a/libs/snowflake/tests/integration_tests/test_create_thread_live.py
+++ b/libs/snowflake/tests/integration_tests/test_create_thread_live.py
@@ -1,0 +1,118 @@
+# ruff: noqa: T201
+"""Live integration test: create_thread() against real Snowflake.
+
+Verifies the empty payload fix works end-to-end by calling the
+Threads API at /api/v2/cortex/threads on a live Snowflake account.
+
+Usage:
+    SNOWFLAKE_PAT=<your_pat> python tests/integration_tests/test_create_thread_live.py
+"""
+
+import os
+import sys
+
+import pytest
+import requests
+
+ACCOUNT = os.getenv("SNOWFLAKE_ACCOUNT", "")
+PAT = os.getenv("SNOWFLAKE_PAT", "")
+
+BASE_URL = f"https://{ACCOUNT}.snowflakecomputing.com"
+THREADS_URL = f"{BASE_URL}/api/v2/cortex/threads"
+
+HEADERS = {
+    "Authorization": f"Bearer {PAT}",
+    "X-Snowflake-Authorization-Token-Type": "PROGRAMMATIC_ACCESS_TOKEN",
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+}
+
+
+skip_no_pat = pytest.mark.skipif(not PAT or not ACCOUNT, reason="SNOWFLAKE_ACCOUNT/SNOWFLAKE_PAT not set")
+
+
+@skip_no_pat
+def test_create_thread_empty_body():
+    """Test 1: POST /api/v2/cortex/threads with empty JSON body {}.
+
+    This is what create_thread() sends after the fix.
+    Before the fix, no body was sent at all, causing a 400.
+    """
+    print("--- Test 1: POST with empty JSON body {} (the fix) ---")
+    resp = requests.post(THREADS_URL, headers=HEADERS, json={}, timeout=30)
+    print(f"Status: {resp.status_code}")
+    print(f"Response: {resp.text[:500]}")
+
+    if resp.status_code == 200:
+        data = resp.json()
+        thread_id = data.get("thread_id")
+        print(f"SUCCESS: thread_id = {thread_id}")
+        return thread_id
+    else:
+        print(f"FAILED: Expected 200, got {resp.status_code}")
+        sys.exit(1)
+
+
+@skip_no_pat
+def test_create_thread_no_body():
+    """Test 2: POST /api/v2/cortex/threads with NO body at all.
+
+    This is what create_thread() sent BEFORE the fix (the bug).
+    Expected: 400 Bad Request.
+    """
+    print("\n--- Test 2: POST with NO body (the bug) ---")
+    headers_no_json = {k: v for k, v in HEADERS.items() if k != "Content-Type"}
+    resp = requests.post(THREADS_URL, headers=headers_no_json, timeout=30)
+    print(f"Status: {resp.status_code}")
+    print(f"Response: {resp.text[:500]}")
+
+    if resp.status_code == 400:
+        print("CONFIRMED: No body → 400 (this was the bug)")
+    else:
+        print(f"Note: Got {resp.status_code} instead of 400")
+
+
+@skip_no_pat
+def test_create_thread_with_metadata():
+    """Test 3: POST with metadata (the workaround that always worked)."""
+    print("\n--- Test 3: POST with metadata (workaround) ---")
+    payload = {"origin_application": "integration_test"}
+    resp = requests.post(THREADS_URL, headers=HEADERS, json=payload, timeout=30)
+    print(f"Status: {resp.status_code}")
+    print(f"Response: {resp.text[:500]}")
+
+    if resp.status_code == 200:
+        data = resp.json()
+        thread_id = data.get("thread_id")
+        print(f"SUCCESS: thread_id = {thread_id}")
+        return thread_id
+    else:
+        print(f"FAILED: Expected 200, got {resp.status_code}")
+        sys.exit(1)
+
+
+def cleanup_thread(thread_id):
+    """Delete a test thread."""
+    if not thread_id:
+        return
+    resp = requests.delete(f"{THREADS_URL}/{thread_id}", headers=HEADERS, timeout=30)
+    print(f"Deleted thread {thread_id}: {resp.status_code}")
+
+
+if __name__ == "__main__":
+    if not PAT or not ACCOUNT:
+        print("ERROR: Set SNOWFLAKE_ACCOUNT and SNOWFLAKE_PAT environment variables")
+        sys.exit(1)
+
+    print(f"Account: {ACCOUNT}")
+    print(f"URL: {THREADS_URL}\n")
+
+    tid1 = test_create_thread_empty_body()
+    test_create_thread_no_body()
+    tid2 = test_create_thread_with_metadata()
+
+    print("\n--- Cleanup ---")
+    cleanup_thread(tid1)
+    cleanup_thread(tid2)
+
+    print("\nAll tests passed!")

--- a/libs/snowflake/tests/unit_tests/test_empty_payload_bug.py
+++ b/libs/snowflake/tests/unit_tests/test_empty_payload_bug.py
@@ -1,0 +1,182 @@
+"""Test to reproduce the empty payload bug in RestApiClient.prepare_request().
+
+Bug: When create_thread() is called without metadata, payload={} is passed to
+prepare_request(). The check `if payload:` treats {} as falsy, so the POST
+request is sent without a JSON body. Snowflake returns 400 Bad Request.
+
+Reference: https://sailpoint customer report, langchain-snowflake v0.2.3
+"""
+
+from unittest.mock import MagicMock, patch
+
+from langchain_snowflake._connection.rest_client import RestApiClient
+
+
+class TestEmptyPayloadBug:
+    """Reproduce the empty payload bug in rest_client.py:79."""
+
+    @patch.object(
+        RestApiClient, "_build_simple_url", return_value="https://test.snowflakecomputing.com/api/v2/cortex/threads"
+    )
+    @patch(
+        "langchain_snowflake._connection.rest_client.SnowflakeAuthUtils.get_rest_api_headers",
+        return_value={"Authorization": "Bearer test", "Content-Type": "application/json"},
+    )
+    def test_empty_dict_payload_is_included_in_request(self, mock_headers, mock_url):
+        """Empty dict payload {} must be included in the request config.
+
+        Previously this was a bug: `if payload:` treated {} as falsy, causing
+        create_thread() without metadata to send a POST with no body (400 error).
+        Fixed by changing to `if payload is not None:`.
+        """
+        mock_session = MagicMock()
+
+        request_config = RestApiClient.prepare_request(
+            session=mock_session,
+            endpoint="/cortex/threads",
+            method="POST",
+            payload={},
+        )
+
+        assert "json" in request_config, "Empty dict payload {} must be included in request config."
+        assert request_config["json"] == {}
+
+
+class TestCreateThreadEndToEnd:
+    """End-to-end test simulating the customer's exact call: create_thread() with no args."""
+
+    @patch.object(RestApiClient, "make_sync_request", return_value={"thread_id": "12345"})
+    @patch.object(
+        RestApiClient, "_build_simple_url", return_value="https://test.snowflakecomputing.com/api/v2/cortex/threads"
+    )
+    @patch(
+        "langchain_snowflake._connection.rest_client.SnowflakeAuthUtils.get_rest_api_headers",
+        return_value={"Authorization": "Bearer test", "Content-Type": "application/json"},
+    )
+    @patch("langchain_snowflake._connection.session_manager.SnowflakeSessionManager.get_or_create_session")
+    def test_create_thread_no_metadata(self, mock_session_mgr, mock_headers, mock_url, mock_request):
+        """create_thread() with no arguments must send a POST with an empty JSON body."""
+        from langchain_snowflake.agents.base import SnowflakeCortexAgent
+
+        mock_session = MagicMock()
+        mock_session.get_current_account.return_value = "test-account"
+        mock_session_mgr.return_value = mock_session
+
+        agent = SnowflakeCortexAgent(
+            name="test_agent",
+            database="test_db",
+            schema="test_schema",
+            session=mock_session,
+        )
+
+        thread_id = agent.create_thread()
+
+        assert thread_id == "12345"
+        mock_request.assert_called_once()
+        call_args = mock_request.call_args
+        request_config = call_args[0][0]
+        assert "json" in request_config, (
+            "create_thread() without metadata must include an empty JSON body in the request"
+        )
+        assert request_config["json"] == {}
+
+    @patch.object(RestApiClient, "make_sync_request", return_value={"thread_id": "67890"})
+    @patch.object(
+        RestApiClient, "_build_simple_url", return_value="https://test.snowflakecomputing.com/api/v2/cortex/threads"
+    )
+    @patch(
+        "langchain_snowflake._connection.rest_client.SnowflakeAuthUtils.get_rest_api_headers",
+        return_value={"Authorization": "Bearer test", "Content-Type": "application/json"},
+    )
+    @patch("langchain_snowflake._connection.session_manager.SnowflakeSessionManager.get_or_create_session")
+    def test_create_thread_with_metadata(self, mock_session_mgr, mock_headers, mock_url, mock_request):
+        """create_thread() with metadata must include it in the JSON body."""
+        from langchain_snowflake.agents.base import SnowflakeCortexAgent
+
+        mock_session = MagicMock()
+        mock_session.get_current_account.return_value = "test-account"
+        mock_session_mgr.return_value = mock_session
+
+        agent = SnowflakeCortexAgent(
+            name="test_agent",
+            database="test_db",
+            schema="test_schema",
+            session=mock_session,
+        )
+
+        thread_id = agent.create_thread(metadata={"app": "sailpoint"})
+
+        assert thread_id == "67890"
+        mock_request.assert_called_once()
+        call_args = mock_request.call_args
+        request_config = call_args[0][0]
+        assert "json" in request_config
+        assert request_config["json"] == {"metadata": {"app": "sailpoint"}}
+
+    @patch.object(
+        RestApiClient, "_build_simple_url", return_value="https://test.snowflakecomputing.com/api/v2/cortex/threads"
+    )
+    @patch(
+        "langchain_snowflake._connection.rest_client.SnowflakeAuthUtils.get_rest_api_headers",
+        return_value={"Authorization": "Bearer test", "Content-Type": "application/json"},
+    )
+    def test_none_payload_is_excluded_from_request(self, mock_headers, mock_url):
+        """None payload should correctly be excluded — this is expected behavior."""
+        mock_session = MagicMock()
+
+        request_config = RestApiClient.prepare_request(
+            session=mock_session,
+            endpoint="/cortex/threads",
+            method="POST",
+            payload=None,
+        )
+
+        assert "json" not in request_config
+
+    @patch.object(
+        RestApiClient, "_build_simple_url", return_value="https://test.snowflakecomputing.com/api/v2/cortex/threads"
+    )
+    @patch(
+        "langchain_snowflake._connection.rest_client.SnowflakeAuthUtils.get_rest_api_headers",
+        return_value={"Authorization": "Bearer test", "Content-Type": "application/json"},
+    )
+    def test_nonempty_payload_is_included(self, mock_headers, mock_url):
+        """Non-empty payload should be included — this works correctly today."""
+        mock_session = MagicMock()
+
+        request_config = RestApiClient.prepare_request(
+            session=mock_session,
+            endpoint="/cortex/threads",
+            method="POST",
+            payload={"metadata": {"app": "sailpoint"}},
+        )
+
+        assert "json" in request_config
+        assert request_config["json"] == {"metadata": {"app": "sailpoint"}}
+
+    @patch.object(
+        RestApiClient, "_build_simple_url", return_value="https://test.snowflakecomputing.com/api/v2/cortex/threads"
+    )
+    @patch(
+        "langchain_snowflake._connection.rest_client.SnowflakeAuthUtils.get_rest_api_headers",
+        return_value={"Authorization": "Bearer test", "Content-Type": "application/json"},
+    )
+    def test_empty_dict_payload_should_be_included_after_fix(self, mock_headers, mock_url):
+        """EXPECTED after fix: Empty dict {} should be included in request config.
+
+        This test will FAIL on the current buggy code and PASS after the fix.
+        """
+        mock_session = MagicMock()
+
+        request_config = RestApiClient.prepare_request(
+            session=mock_session,
+            endpoint="/cortex/threads",
+            method="POST",
+            payload={},
+        )
+
+        assert "json" in request_config, (
+            "FAILS: Empty dict payload {} was dropped from request config. "
+            "Fix rest_client.py:79 from `if payload:` to `if payload is not None:`"
+        )
+        assert request_config["json"] == {}


### PR DESCRIPTION
`create_thread()` without metadata builds `payload = {}`. The check `if payload:` treated `{}` as falsy, so the POST to `/api/v2/cortex/threads` was sent without a body — Snowflake returns 400/415 when no JSON body is present.

Changed `if payload:` to `if payload is not None:` so that `{}` is correctly included as a JSON body.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)