### PR TITLE
Update PyJWT for Dependabot alert

### DIFF
--- a/libs/snowflake/poetry.lock
+++ b/libs/snowflake/poetry.lock
@@ -2085,14 +2085,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pyjwt"
-version = "2.12.0"
+version = "2.13.0"
 description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pyjwt-2.12.0-py3-none-any.whl", hash = "sha256:9bb459d1bdd0387967d287f5656bf7ec2b9a26645d1961628cda1764e087fd6e"},
-    {file = "pyjwt-2.12.0.tar.gz", hash = "sha256:2f62390b667cd8257de560b850bb5a883102a388829274147f1d724453f8fb02"},
+    {file = "pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728"},
+    {file = "pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423"},
 ]
 
 [package.extras]


### PR DESCRIPTION
## Summary
- Updates `pyjwt` in `libs/snowflake/poetry.lock` from 2.12.0 to 2.13.0 to address GHSA-993g-76c3-p5m4 / CVE-2026-48522 and GHSA-fhv5-28vv-h8m8 / CVE-2026-48524.
- Keeps the change scoped to the affected lockfile entry.

## Validation
- [x] `SFW_SKIP_UPDATE_CHECK=1 sfw uv tool run poetry check --lock --directory libs/snowflake`

## Notes
- `poetry update pyjwt --directory libs/snowflake` was attempted through `sfw` but Poetry's PyPI connection failed due a TLS CA issue in the sandbox firewall wrapper. Since only the locked PyJWT artifact changed, the lock entry was updated directly using PyPI metadata and then validated with `poetry check --lock`.
- Scoped Dependabot alert remediation; not intended to merge automatically.